### PR TITLE
bug fix: set the correct ordering of dimensions in the input tensor

### DIFF
--- a/models/hierarchical.py
+++ b/models/hierarchical.py
@@ -77,7 +77,10 @@ class TabFormerEmbeddings(nn.Module):
         inputs_embeds = self.word_embeddings(input_ids)
         embeds_shape = list(inputs_embeds.size())
 
-        inputs_embeds = self.transformer_encoder(inputs_embeds.view([-1] + embeds_shape[-2:]))
+        inputs_embeds = inputs_embeds.view([embeds_shape[0], -1, embeds_shape[-1]])
+	inputs_embeds = inputs_embeds.permute(1, 0, 2)
+	inputs_embeds = self.transformer_encoder(inputs_embeds)
+	inputs_embeds = inputs_embeds.permute(1, 0, 2).contiguous()
         inputs_embeds = self.lin_proj(inputs_embeds.view(embeds_shape[:-2] + [-1]))
 
         return inputs_embeds


### PR DESCRIPTION
self.transformer_encoder (which passes through nn.MultiheadAttention) expects the batch size to be in the second dimension of the input tensor, however the current implementation places the batch size in the first dimension which causes an incorrect computation during multiheaded attention - this commit swaps the batch size of the input tensor from the first dimension to the second and then after passing through self.transformer_encoder, the batch size is swapped back to the first dimension, because the following layers in the architecture expects the batch size to be in the first dimension. The current version of PyTorch has a boolean argument for nn.TransformerEncoderLayer called batch_first which allows the batch size of the input tensor to be in the first dimension, however this commit is assuming an older version of PyTorch (e.g. PyTorch 1.6.0, the current version used in this project) which does not have this boolean argument.