### PR TITLE
changes to support transformers v4.x

### DIFF
--- a/models/tabformer_bert.py
+++ b/models/tabformer_bert.py
@@ -4,7 +4,7 @@ from torch.nn import CrossEntropyLoss
 
 from transformers.models.bert.modeling_bert import ACT2FN
 from transformers.models.bert.modeling_bert import BertForMaskedLM
-from transformers.configuration_bert import BertConfig
+from transformers.models.bert.configuration_bert import BertConfig
 from models.custom_criterion import CustomAdaptiveLogSoftmax
 
 

--- a/models/tabformer_bert.py
+++ b/models/tabformer_bert.py
@@ -2,8 +2,8 @@ import torch
 from torch import nn
 from torch.nn import CrossEntropyLoss
 
-from transformers.modeling_bert import ACT2FN, BertLayerNorm
-from transformers.modeling_bert import BertForMaskedLM
+from transformers.models.bert.modeling_bert import ACT2FN
+from transformers.models.bert.modeling_bert import BertForMaskedLM
 from transformers.configuration_bert import BertConfig
 from models.custom_criterion import CustomAdaptiveLogSoftmax
 
@@ -37,7 +37,7 @@ class TabFormerBertPredictionHeadTransform(nn.Module):
             self.transform_act_fn = ACT2FN[config.hidden_act]
         else:
             self.transform_act_fn = config.hidden_act
-        self.LayerNorm = BertLayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
     def forward(self, hidden_states):
         hidden_states = self.dense(hidden_states)

--- a/models/tabformer_gpt2.py
+++ b/models/tabformer_gpt2.py
@@ -1,6 +1,6 @@
 from torch.nn import CrossEntropyLoss
 
-from transformers.modeling_gpt2 import GPT2LMHeadModel
+from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
 
 
 class TabFormerGPT2LMHeadModel(GPT2LMHeadModel):


### PR DESCRIPTION
* Changed the way of calling modeling_bert and modeling_gpt2 modules based on the transformer v3.x
* Replaced ``BertLayerNorm`` with ``torch.nn.LayerNorm``